### PR TITLE
Align contract server resolution with the GCP connector

### DIFF
--- a/src/main/java/entropydata/databricks/DatabricksAccessManagementHandler.java
+++ b/src/main/java/entropydata/databricks/DatabricksAccessManagementHandler.java
@@ -13,6 +13,7 @@ import com.databricks.sdk.service.iam.ComplexValue;
 import com.databricks.sdk.service.iam.Group;
 import com.databricks.sdk.service.iam.ListAccountGroupsRequest;
 import com.databricks.sdk.service.iam.ServicePrincipal;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import entropydata.sdk.EntropyDataClient;
 import entropydata.sdk.EntropyDataEventHandler;
@@ -20,11 +21,11 @@ import entropydata.sdk.client.ApiException;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
 import entropydata.sdk.client.model.AccessDeactivatedEvent;
-import entropydata.sdk.client.model.DataContract;
 import entropydata.sdk.client.model.DataProduct;
 import entropydata.sdk.client.model.Team;
 import entropydata.sdk.client.model.TeamMembersInner;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -94,10 +95,11 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
 
   /**
    * Resolves the Databricks server (catalog/schema/host) for the provider output port of this access.
-   * The server details live in the linked data contract (ODCS), where {@code catalog} is a first-class
-   * Databricks server field. Returns {@code null} when the access is not applicable for this connector,
-   * i.e. the output port is not a Databricks port, no server could be resolved, or the server host does
-   * not match this connector's workspace.
+   * The server details live in the linked data contract, where {@code catalog} is a first-class
+   * Databricks server field, with the output port's own server config as fallback. Returns {@code null}
+   * when the access is not applicable for this connector, i.e. the output port is not a Databricks port,
+   * no server with catalog and schema could be resolved, or the server host does not match this
+   * connector's workspace.
    */
   private Map<String, String> resolveProviderServer(Access access) {
     var provider = access.getProvider();
@@ -122,9 +124,13 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
       return null;
     }
 
+    // Resolve server config: first try data contract, then fall back to direct server field
     var server = resolveServerFromContract(outputPort);
     if (server == null) {
-      log.info("No data contract server could be resolved for dataProductId {}, outputPortId {}", dataProductId, outputPortId);
+      server = resolveServerFromOutputPort(outputPort);
+    }
+    if (server == null) {
+      log.info("No server could be resolved for dataProductId {}, outputPortId {}", dataProductId, outputPortId);
       return null;
     }
 
@@ -132,6 +138,11 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
     if (!hostnamesMatch(serverHost)) {
       log.info("Hostnames do not match: entropydata.client.databricks.workspace.host={} and server.host={}",
           workspaceClient.config().getHost(), serverHost);
+      return null;
+    }
+
+    if (server.get("catalog") == null || server.get("schema") == null) {
+      log.info("Server for dataProductId {}, outputPortId {} has no catalog or schema", dataProductId, outputPortId);
       return null;
     }
 
@@ -155,16 +166,20 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
   }
 
   /**
-   * Resolves the server from the data contract linked by the output port. The data contract's servers are
-   * returned by the API as a map keyed by server name; a Databricks server carries {@code host},
-   * {@code catalog} and {@code schema}.
+   * Resolves the server from the data contract linked by the output port. A Databricks server carries
+   * {@code host}, {@code catalog} and {@code schema}. The contract is fetched untyped, because the typed
+   * SDK model only supports DCS-shaped servers (a map keyed by server name) and fails to deserialize ODCS
+   * contracts, where servers is a list carrying the name in the {@code server} field.
    */
+  @SuppressWarnings("unchecked")
   private Map<String, String> resolveServerFromContract(Map<String, Object> outputPort) {
+    // Get the data contract ID - DPS uses "dataContractId", ODPS uses "contractId"
     var dataContractId = (String) outputPort.get("dataContractId");
     if (dataContractId == null) {
       dataContractId = (String) outputPort.get("contractId");
     }
     if (dataContractId == null) {
+      // ODPS may store contractId in customProperties
       dataContractId = getCustomPropertyValue(outputPort, "contractId");
     }
     if (dataContractId == null) {
@@ -173,27 +188,83 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
 
     var contractServerName = getOutputPortCustomField(outputPort, "contractServer");
 
-    DataContract dataContract;
+    Map<String, Object> dataContract;
     try {
-      dataContract = client.getDataContractsApi().getDataContract(dataContractId);
+      dataContract = fetchDataContractAsMap(dataContractId);
     } catch (Exception e) {
-      log.debug("Failed to fetch data contract {}: {}", dataContractId, e.getMessage());
+      log.warn("Failed to fetch data contract {}: {}", dataContractId, e.getMessage());
       return null;
     }
 
-    var servers = dataContract.getServers();
-    if (servers == null || servers.isEmpty()) {
-      return null;
+    var servers = dataContract.get("servers");
+
+    // Data Contract Specification (DCS): servers is a Map<String, Server>
+    if (servers instanceof Map) {
+      var serversMap = (Map<String, Map<String, Object>>) servers;
+      Map<String, Object> server;
+      if (contractServerName != null && serversMap.containsKey(contractServerName)) {
+        server = serversMap.get(contractServerName);
+      } else {
+        server = serversMap.values().stream().findFirst().orElse(null);
+      }
+      if (server != null) {
+        return toStringMap(server);
+      }
     }
 
-    Map<String, Object> server;
-    if (contractServerName != null && servers.containsKey(contractServerName)) {
-      server = servers.get(contractServerName);
-    } else {
-      server = servers.values().stream().findFirst().orElse(null);
+    // Open Data Contract Standard (ODCS): servers is a List with "server" field as the name
+    if (servers instanceof List) {
+      var serversList = (List<Map<String, Object>>) servers;
+      Map<String, Object> server;
+      if (contractServerName != null) {
+        server = serversList.stream()
+            .filter(s -> contractServerName.equals(s.get("server")))
+            .findFirst().orElse(serversList.isEmpty() ? null : serversList.get(0));
+      } else {
+        server = serversList.isEmpty() ? null : serversList.get(0);
+      }
+      if (server != null) {
+        return toStringMap(server);
+      }
     }
 
-    return server == null ? null : toStringMap(server);
+    return null;
+  }
+
+  private Map<String, Object> fetchDataContractAsMap(String dataContractId) throws ApiException {
+    var apiClient = client.getApiClient();
+    var path = "/api/datacontracts/" + apiClient.escapeString(dataContractId);
+    return apiClient.invokeAPI(
+        path,
+        "GET",
+        new ArrayList<>(),
+        new ArrayList<>(),
+        "",
+        null,
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        "application/json",
+        null,
+        new String[] {"ApiKeyAuth", "BearerAuth"},
+        new TypeReference<Map<String, Object>>() {});
+  }
+
+  @SuppressWarnings("unchecked")
+  private Map<String, String> resolveServerFromOutputPort(Map<String, Object> outputPort) {
+    // DPS format: direct "server" field
+    if (outputPort.containsKey("server") && outputPort.get("server") instanceof Map) {
+      return toStringMap((Map<String, Object>) outputPort.get("server"));
+    }
+    // ODPS format: server in customProperties
+    if (outputPort.containsKey("customProperties") && outputPort.get("customProperties") instanceof List) {
+      for (var prop : (List<Map<String, Object>>) outputPort.get("customProperties")) {
+        if ("server".equals(prop.get("property")) && prop.get("value") instanceof Map) {
+          return toStringMap((Map<String, Object>) prop.get("value"));
+        }
+      }
+    }
+    return null;
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/entropydata/databricks/DatabricksAccessManagementHandlerTest.java
+++ b/src/test/java/entropydata/databricks/DatabricksAccessManagementHandlerTest.java
@@ -16,19 +16,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import entropydata.sdk.EntropyDataClient;
 import entropydata.sdk.client.ApiClient;
 import entropydata.sdk.client.api.AccessApi;
-import entropydata.sdk.client.api.DataContractsApi;
 import entropydata.sdk.client.api.DataProductsApi;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
 import entropydata.sdk.client.model.AccessProvider;
-import entropydata.sdk.client.model.DataContract;
-import entropydata.sdk.client.model.DataContractServersValue;
 import entropydata.sdk.client.model.DataUsageAgreementConsumer;
 import entropydata.sdk.client.model.DataUsageAgreementInfo;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +34,7 @@ class DatabricksAccessManagementHandlerTest {
   private EntropyDataClient client;
   private AccessApi accessApi;
   private DataProductsApi dataProductsApi;
-  private DataContractsApi dataContractsApi;
+  private ApiClient apiClient;
   private ObjectMapper objectMapper;
 
   private WorkspaceClient workspaceClient;
@@ -52,18 +47,16 @@ class DatabricksAccessManagementHandlerTest {
     client = mock(EntropyDataClient.class);
     accessApi = mock(AccessApi.class);
     dataProductsApi = mock(DataProductsApi.class);
-    dataContractsApi = mock(DataContractsApi.class);
     workspaceClient = mock(WorkspaceClient.class, RETURNS_DEEP_STUBS);
     accountClient = mock(AccountClient.class, RETURNS_DEEP_STUBS);
 
-    var apiClient = mock(ApiClient.class);
+    apiClient = mock(ApiClient.class);
     objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     when(client.getApiClient()).thenReturn(apiClient);
     when(apiClient.getObjectMapper()).thenReturn(objectMapper);
     when(client.getAccessApi()).thenReturn(accessApi);
     when(client.getDataProductsApi()).thenReturn(dataProductsApi);
-    when(client.getDataContractsApi()).thenReturn(dataContractsApi);
 
     handler = new DatabricksAccessManagementHandler(client, workspaceClient, accountClient);
   }
@@ -72,7 +65,7 @@ class DatabricksAccessManagementHandlerTest {
   void grantsOnCatalogAndSchemaResolvedFromOdcsContract() throws Exception {
     when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
     when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
-    when(dataContractsApi.getDataContract("my-contract")).thenReturn(loadDataContract("datacontract-databricks.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
     when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
 
     var event = new AccessActivatedEvent();
@@ -85,10 +78,26 @@ class DatabricksAccessManagementHandlerTest {
   }
 
   @Test
+  void grantsOnCatalogAndSchemaResolvedFromDcsContract() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks-dcs.yaml");
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    handler.onAccessActivatedEvent(event);
+
+    // DCS contracts carry servers as a map keyed by server name
+    verify(workspaceClient.schemas()).get("my_catalog.my_schema");
+    verify(workspaceClient.grants()).update(any(UpdatePermissions.class));
+  }
+
+  @Test
   void matchesWhenContractServerHostHasNoScheme() throws Exception {
     when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
     when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
-    when(dataContractsApi.getDataContract("my-contract")).thenReturn(loadDataContract("datacontract-databricks-schemeless-host.yaml"));
+    stubDataContract("datacontract-databricks-schemeless-host.yaml");
     when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
 
     var event = new AccessActivatedEvent();
@@ -104,7 +113,7 @@ class DatabricksAccessManagementHandlerTest {
   void skipsWhenServerHostDoesNotMatchWorkspace() throws Exception {
     when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
     when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
-    when(dataContractsApi.getDataContract("my-contract")).thenReturn(loadDataContract("datacontract-databricks.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
     when(workspaceClient.config().getHost()).thenReturn("https://dbc-other.cloud.databricks.com");
 
     var event = new AccessActivatedEvent();
@@ -113,6 +122,45 @@ class DatabricksAccessManagementHandlerTest {
 
     verify(workspaceClient.schemas(), never()).get(anyString());
     verify(workspaceClient.grants(), never()).update(any(UpdatePermissions.class));
+  }
+
+  @Test
+  void fallsBackToOutputPortServerWhenContractFetchFails() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp"))
+        .thenReturn(loadYaml("provider-dp-databricks-odps-port-server.yaml"));
+    when(apiClient.<Map<String, Object>>invokeAPI(anyString(), anyString(), any(), any(), any(), any(),
+        any(), any(), any(), any(), any(), any(), any()))
+        .thenThrow(new RuntimeException("contract not found"));
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    handler.onAccessActivatedEvent(event);
+
+    verify(workspaceClient.schemas()).get("port_catalog.port_schema");
+    verify(workspaceClient.grants()).update(any(UpdatePermissions.class));
+  }
+
+  @Test
+  void skipsWhenResolvedServerHasNoCatalog() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks-no-catalog.yaml");
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    handler.onAccessActivatedEvent(event);
+
+    verify(workspaceClient.schemas(), never()).get(anyString());
+    verify(workspaceClient.grants(), never()).update(any(UpdatePermissions.class));
+  }
+
+  private void stubDataContract(String name) throws Exception {
+    when(apiClient.<Map<String, Object>>invokeAPI(anyString(), anyString(), any(), any(), any(), any(),
+        any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(loadYaml(name));
   }
 
   private Access activeUserAccess() {
@@ -129,32 +177,6 @@ class DatabricksAccessManagementHandlerTest {
     try (InputStream is = DatabricksAccessManagementHandlerTest.class.getResourceAsStream("/fixtures/" + name)) {
       return new Yaml().load(is);
     }
-  }
-
-  /**
-   * Load an ODCS data contract YAML and convert to the SDK DataContract model. ODCS uses servers as a
-   * list; the SDK model uses servers as a map keyed by server name, matching what the API returns after
-   * deserialization.
-   */
-  @SuppressWarnings("unchecked")
-  private DataContract loadDataContract(String name) throws IOException {
-    var yaml = loadYaml(name);
-    var servers = yaml.get("servers");
-    if (servers instanceof List) {
-      var serversMap = new LinkedHashMap<String, DataContractServersValue>();
-      for (var entry : (List<Map<String, Object>>) servers) {
-        var serverName = (String) entry.get("server");
-        var serverValue = new DataContractServersValue();
-        entry.forEach((k, v) -> {
-          if (!"server".equals(k)) {
-            serverValue.put(k, v);
-          }
-        });
-        serversMap.put(serverName, serverValue);
-      }
-      yaml.put("servers", serversMap);
-    }
-    return objectMapper.convertValue(yaml, DataContract.class);
   }
 
 }

--- a/src/test/resources/fixtures/datacontract-databricks-dcs.yaml
+++ b/src/test/resources/fixtures/datacontract-databricks-dcs.yaml
@@ -1,0 +1,12 @@
+dataContractSpecification: 1.1.0
+id: my-contract
+info:
+  title: Test Contract
+  version: 1.0.0
+  status: active
+servers:
+  databricks-server:
+    type: databricks
+    host: https://dbc-abc.cloud.databricks.com
+    catalog: my_catalog
+    schema: my_schema

--- a/src/test/resources/fixtures/datacontract-databricks-no-catalog.yaml
+++ b/src/test/resources/fixtures/datacontract-databricks-no-catalog.yaml
@@ -1,0 +1,11 @@
+apiVersion: v3.1.0
+kind: DataContract
+id: my-contract
+name: Test Contract
+version: 1.0.0
+status: active
+servers:
+  - server: databricks-server
+    type: databricks
+    host: https://dbc-abc.cloud.databricks.com
+    schema: my_schema

--- a/src/test/resources/fixtures/provider-dp-databricks-odps-port-server.yaml
+++ b/src/test/resources/fixtures/provider-dp-databricks-odps-port-server.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1.0.0
+kind: DataProduct
+id: provider-dp
+name: Provider Data Product
+status: active
+outputPorts:
+  - id: op-databricks
+    name: databricks-output
+    type: databricks
+    contractId: my-contract
+    customProperties:
+      - property: server
+        value:
+          host: https://dbc-abc.cloud.databricks.com
+          catalog: port_catalog
+          schema: port_schema


### PR DESCRIPTION
## Summary

Access management silently skipped every output port whose linked data contract is ODCS: the typed SDK model declares `servers` as `Map<String, Server>` (DCS shape), so deserialization throws `MismatchedInputException` on the ODCS list shape before any server can be read — and the exception was only logged at DEBUG, leaving just a misleading `No data contract server could be resolved` at INFO.

This aligns the server resolution with the GCP connector's strategy, with one deliberate improvement over it:

- **Fetch the data contract untyped** (raw `Map` via `invokeAPI`) so both server shapes can actually be inspected — DCS map keyed by server name, and ODCS list carrying the name in the `server` field (matched against the output port's `contractServer` hint, falling back to the first server).
- **Fall back to the output port's own server config** (DPS `server` field or ODPS `server` custom property) when the contract yields none.
- **Log contract fetch failures at WARN** instead of DEBUG.
- **Guard against servers without `catalog`/`schema`** so a partial config can't produce a `null.null` schema grant.

Tests now feed the ODCS fixtures raw instead of pre-converting them to the typed map shape (which had masked the bug), plus new cases for DCS-shaped servers, the output-port fallback, and the missing-catalog guard.