### PR TITLE
Report access provisioning state after granting and revoking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<dependency>
 			<groupId>com.entropy-data</groupId>
 			<artifactId>entropy-data-sdk</artifactId>
-			<version>0.1.2</version>
+			<version>0.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.databricks</groupId>

--- a/src/main/java/entropydata/databricks/DatabricksAccessManagementHandler.java
+++ b/src/main/java/entropydata/databricks/DatabricksAccessManagementHandler.java
@@ -28,6 +28,10 @@ import entropydata.sdk.client.ApiException;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
 import entropydata.sdk.client.model.AccessDeactivatedEvent;
+import entropydata.sdk.client.model.AccessDeprovisioningSucceededReport;
+import entropydata.sdk.client.model.AccessProvisioningFailedReport;
+import entropydata.sdk.client.model.AccessProvisioningStartedReport;
+import entropydata.sdk.client.model.AccessProvisioningSucceededReport;
 import entropydata.sdk.client.model.DataProduct;
 import entropydata.sdk.client.model.Team;
 import entropydata.sdk.client.model.TeamMembersInner;
@@ -45,6 +49,11 @@ import org.slf4j.LoggerFactory;
 public class DatabricksAccessManagementHandler implements EntropyDataEventHandler {
 
   private static final Logger log = LoggerFactory.getLogger(DatabricksAccessManagementHandler.class);
+
+  // Reported back to Entropy Data on every provisioning transition, so the access page shows which
+  // platform holds the grant and which component created it.
+  private static final String PLATFORM = "databricks";
+  private static final String EXECUTOR = "Entropy Data Databricks Connector";
 
   private final EntropyDataClient client;
   private final WorkspaceClient workspaceClient;
@@ -78,7 +87,19 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
       log.info("Access {} is not active, skip granting permissions", access.getId());
       return;
     }
-    grantPermissions(access, server);
+
+    var schemaFullName = server.get("catalog") + "." + server.get("schema");
+    reportProvisioningStarted(access);
+    try {
+      grantPermissions(access, server);
+    } catch (RuntimeException e) {
+      log.error("Failed to grant permissions for access {}", access.getId(), e);
+      reportProvisioningFailed(access, e);
+      // Swallow after reporting: the failure is now recorded and mailed to the provider, whereas
+      // rethrowing would stall the whole event feed on this one access until it is retried.
+      return;
+    }
+    reportProvisioningSucceeded(access, schemaFullName);
   }
 
   @Override
@@ -93,11 +114,81 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
       log.info("Access {} is not applicable for Databricks access management", access.getId());
       return;
     }
-    revokePermissions(access);
+
+    var accessGroupName = "access-" + access.getId();
+    reportDeprovisioningStarted(access);
+    try {
+      revokePermissions(access);
+    } catch (RuntimeException e) {
+      log.error("Failed to revoke permissions for access {}", access.getId(), e);
+      reportDeprovisioningFailed(access, e);
+      return;
+    }
+    reportDeprovisioningSucceeded(access, accessGroupName);
   }
 
   private boolean isActive(Access access) {
     return Objects.equals(access.getInfo().getActive(), Boolean.TRUE);
+  }
+
+  private void reportProvisioningStarted(Access access) {
+    safeReport(access.getId(), "provisioning-started", () ->
+        client.getAccessApi().reportProvisioningStarted(access.getId(),
+            new AccessProvisioningStartedReport().platform(PLATFORM).executor(EXECUTOR)));
+  }
+
+  private void reportProvisioningSucceeded(Access access, String reference) {
+    safeReport(access.getId(), "provisioning-succeeded", () ->
+        client.getAccessApi().reportProvisioningSucceeded(access.getId(),
+            new AccessProvisioningSucceededReport().platform(PLATFORM).executor(EXECUTOR).reference(reference)));
+  }
+
+  private void reportProvisioningFailed(Access access, Exception cause) {
+    safeReport(access.getId(), "provisioning-failed", () ->
+        client.getAccessApi().reportProvisioningFailed(access.getId(),
+            new AccessProvisioningFailedReport().platform(PLATFORM).executor(EXECUTOR).diagnostics(diagnostics(cause))));
+  }
+
+  private void reportDeprovisioningStarted(Access access) {
+    safeReport(access.getId(), "deprovisioning-started", () ->
+        client.getAccessApi().reportDeprovisioningStarted(access.getId(),
+            new AccessProvisioningStartedReport().platform(PLATFORM).executor(EXECUTOR)));
+  }
+
+  private void reportDeprovisioningSucceeded(Access access, String reference) {
+    safeReport(access.getId(), "deprovisioning-succeeded", () ->
+        client.getAccessApi().reportDeprovisioningSucceeded(access.getId(),
+            new AccessDeprovisioningSucceededReport().platform(PLATFORM).executor(EXECUTOR).reference(reference)));
+  }
+
+  private void reportDeprovisioningFailed(Access access, Exception cause) {
+    safeReport(access.getId(), "deprovisioning-failed", () ->
+        client.getAccessApi().reportDeprovisioningFailed(access.getId(),
+            new AccessProvisioningFailedReport().platform(PLATFORM).executor(EXECUTOR).diagnostics(diagnostics(cause))));
+  }
+
+  /**
+   * Reports one transition, swallowing any failure. The grant itself is the source of truth; a
+   * report that cannot be delivered (e.g. the backend predates provisioning, or the API key lacks
+   * the provider's ACCESS_EDIT permission) must not undo or block the grant.
+   */
+  private void safeReport(String accessId, String transition, ReportCall call) {
+    try {
+      call.run();
+      log.info("Reported {} for access {}", transition, accessId);
+    } catch (Exception e) {
+      log.warn("Failed to report {} for access {}: {}", transition, accessId, e.getMessage());
+    }
+  }
+
+  private static String diagnostics(Exception cause) {
+    var message = cause.getMessage();
+    return message != null ? message : cause.getClass().getSimpleName();
+  }
+
+  @FunctionalInterface
+  private interface ReportCall {
+    void run() throws ApiException;
   }
 
   /**
@@ -354,8 +445,6 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
     }
 
     grantSchemaPermissions(server.get("catalog"), schemaFullName, accessGroup.getDisplayName());
-
-    // TODO: update access resource in Entropy Data with logs
   }
 
   /**
@@ -590,8 +679,6 @@ public class DatabricksAccessManagementHandler implements EntropyDataEventHandle
                     .setPrincipal(principal)
                     .setAdd(List.of(Privilege.USE_SCHEMA, Privilege.SELECT)))));
     log.info("Granted permissions: {}", grantedPermissions);
-
-    // TODO return log information
   }
 
   private Access getAccess(String accessId) {

--- a/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
+++ b/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
@@ -9,7 +9,7 @@ import com.databricks.sdk.service.catalog.TableInfo;
 import entropydata.sdk.EntropyDataAssetsProvider;
 import entropydata.sdk.EntropyDataStateRepository;
 import entropydata.sdk.client.model.Asset;
-import entropydata.sdk.client.model.AssetColumnsInner;
+import entropydata.sdk.client.model.AssetColumn;
 import entropydata.sdk.client.model.AssetInfo;
 import entropydata.sdk.client.model.AssetRelationshipsInner;
 import java.util.List;
@@ -205,7 +205,7 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
 
     if (table.getColumns() != null) {
       for (var column : table.getColumns()) {
-        asset.addColumnsItem(new AssetColumnsInner()
+        asset.addColumnsItem(new AssetColumn()
             .name(column.getName())
             .type(column.getTypeText())
             .description(column.getComment()));

--- a/src/test/java/entropydata/databricks/DatabricksAccessManagementHandlerTest.java
+++ b/src/test/java/entropydata/databricks/DatabricksAccessManagementHandlerTest.java
@@ -3,7 +3,9 @@ package entropydata.databricks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
@@ -31,7 +33,12 @@ import entropydata.sdk.client.api.DataProductsApi;
 import entropydata.sdk.client.api.TeamsApi;
 import entropydata.sdk.client.model.Access;
 import entropydata.sdk.client.model.AccessActivatedEvent;
+import entropydata.sdk.client.model.AccessDeactivatedEvent;
+import entropydata.sdk.client.model.AccessDeprovisioningSucceededReport;
 import entropydata.sdk.client.model.AccessProvider;
+import entropydata.sdk.client.model.AccessProvisioningFailedReport;
+import entropydata.sdk.client.model.AccessProvisioningStartedReport;
+import entropydata.sdk.client.model.AccessProvisioningSucceededReport;
 import entropydata.sdk.client.model.DataUsageAgreementConsumer;
 import entropydata.sdk.client.model.DataUsageAgreementInfo;
 import entropydata.sdk.client.model.Team;
@@ -247,6 +254,83 @@ class DatabricksAccessManagementHandlerTest {
         .map(ComplexValue::getValue)
         .toList();
     assertThat(addedMemberValues).contains("user-alice").doesNotContain("alice@example.com");
+  }
+
+  @Test
+  void reportsProvisioningStartedThenSucceededOnGrant() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    handler.onAccessActivatedEvent(event);
+
+    // started is reported before the grant, succeeded after it, with the granted schema as reference
+    var order = inOrder(accessApi);
+    order.verify(accessApi).reportProvisioningStarted(eq("a-1"), any(AccessProvisioningStartedReport.class));
+    var succeeded = ArgumentCaptor.forClass(AccessProvisioningSucceededReport.class);
+    order.verify(accessApi).reportProvisioningSucceeded(eq("a-1"), succeeded.capture());
+    assertThat(succeeded.getValue().getPlatform()).isEqualTo("databricks");
+    assertThat(succeeded.getValue().getReference()).isEqualTo("my_catalog.my_schema");
+    verify(accessApi, never()).reportProvisioningFailed(anyString(), any());
+  }
+
+  @Test
+  void reportsProvisioningFailedWhenGrantThrows() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+    when(workspaceClient.schemas().get(anyString())).thenThrow(new RuntimeException("schema exploded"));
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    // the grant throws, but the handler must swallow it after reporting so the event feed is not stalled
+    handler.onAccessActivatedEvent(event);
+
+    var order = inOrder(accessApi);
+    order.verify(accessApi).reportProvisioningStarted(eq("a-1"), any(AccessProvisioningStartedReport.class));
+    var failed = ArgumentCaptor.forClass(AccessProvisioningFailedReport.class);
+    order.verify(accessApi).reportProvisioningFailed(eq("a-1"), failed.capture());
+    assertThat(failed.getValue().getDiagnostics()).isEqualTo("schema exploded");
+    verify(accessApi, never()).reportProvisioningSucceeded(anyString(), any());
+  }
+
+  @Test
+  void reportsDeprovisioningStartedThenSucceededOnRevoke() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-abc.cloud.databricks.com");
+
+    var event = new AccessDeactivatedEvent();
+    event.setId("a-1");
+    handler.onAccessDeactivatedEvent(event);
+
+    var order = inOrder(accessApi);
+    order.verify(accessApi).reportDeprovisioningStarted(eq("a-1"), any(AccessProvisioningStartedReport.class));
+    var succeeded = ArgumentCaptor.forClass(AccessDeprovisioningSucceededReport.class);
+    order.verify(accessApi).reportDeprovisioningSucceeded(eq("a-1"), succeeded.capture());
+    assertThat(succeeded.getValue().getReference()).isEqualTo("access-a-1");
+  }
+
+  @Test
+  void doesNotReportProvisioningWhenNotApplicable() throws Exception {
+    when(accessApi.getAccess("a-1")).thenReturn(activeUserAccess());
+    when(dataProductsApi.getDataProduct("provider-dp")).thenReturn(loadYaml("provider-dp-databricks-odps.yaml"));
+    stubDataContract("datacontract-databricks.yaml");
+    // a different workspace host: another connector owns this access, so this one must stay silent
+    when(workspaceClient.config().getHost()).thenReturn("https://dbc-other.cloud.databricks.com");
+
+    var event = new AccessActivatedEvent();
+    event.setId("a-1");
+    handler.onAccessActivatedEvent(event);
+
+    verify(accessApi, never()).reportProvisioningStarted(anyString(), any());
+    verify(accessApi, never()).reportProvisioningSucceeded(anyString(), any());
+    verify(accessApi, never()).reportProvisioningFailed(anyString(), any());
   }
 
   private void stubDataContract(String name) throws Exception {


### PR DESCRIPTION
## Summary

The connector now reports the **provisioning state** of a grant back to Entropy Data, using the new `/api/access/{id}/provisioning/*` endpoints.

- **On access activation** (grant): reports `provisioning-started` before the Unity Catalog grant, then `provisioning-succeeded` (with the granted `catalog.schema` as `reference`) — or `provisioning-failed` (with the exception message as `diagnostics`) if the grant throws.
- **On access deactivation** (revoke): reports the `deprovisioning-*` mirror, with the removed `access-<id>` group as `reference`.
- Reports are made **only when the access is applicable to this workspace**, so a connector wired to a different workspace stays silent (no spurious reports).
- A failed grant is **reported and then swallowed** rather than rethrown: `EntropyDataEventListener` only advances its cursor on a clean return, so rethrowing would reprocess the same access every 30s and stall the feed. The failure is recorded and mailed to the provider instead.
- Report calls are **best-effort** — a delivery failure (older backend, missing `ACCESS_EDIT` on the provider team) is logged but never undoes or blocks the grant.

Removes the two `TODO: update access resource in Entropy Data with logs` placeholders this implements.

### SDK bump
Requires **entropy-data-sdk 0.2.1** (companion to entropy-data/entropy-data-sdk#82) for the reporting endpoints. The bump from 0.1.2 also pulls the 0.2.0 spec refresh, which renamed the generated `AssetColumnsInner` model to `AssetColumn` — updated in `DatabricksAssetsSupplier`.

> **CI note:** the SDK 0.2.1 artifact is not on Maven Central yet, so the build will stay red until entropy-data/entropy-data-sdk#82 is merged and released as 0.2.1.

## Testing
`./mvnw test` — 12 tests pass, including 4 new cases: started→succeeded on grant, failed-and-swallowed when the grant throws, deprovision started→succeeded, and no report when the access is not applicable to this workspace.