### PR TITLE
Pin patched Jackson and commons-configuration2 versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,24 @@
 	<name>entropy-data-connector-databricks</name>
 	<description>Entropy Data Connector for Databricks Integration</description>
 
+	<!-- Transitive CVE fixes. Remove once the managed versions catch up:
+	     the jackson properties once a Spring Boot release ships the patched BOMs,
+	     commons-configuration2 once databricks-sdk-java pins >= 2.15.0. -->
+	<properties>
+		<jackson-bom.version>3.1.5</jackson-bom.version>
+		<jackson-2-bom.version>2.21.5</jackson-2-bom.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-configuration2</artifactId>
+				<version>2.15.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 
 		<dependency>


### PR DESCRIPTION
## Summary

Clears the five open Dependabot alerts on this repo. All five are transitive — none of the affected artifacts is declared in `pom.xml` — and no direct dependency bump resolves them:

- Spring Boot 4.1.0 is the latest release, so there is no parent bump carrying patched Jackson BOMs.
- `databricks-sdk-java` 0.136.0 (newer than the 0.132.0 on `main`) still pins `commons-configuration2` 2.13.0, so bumping the SDK does not help either.

| Alert | Package | Before | After |
|---|---|---|---|
| #123 (CVE-2026-59889) | `tools.jackson.core:jackson-databind` | 3.1.4 | 3.1.5 |
| #122 (CVE-2026-59889) | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #121 (GHSA-mhm7-754m-9p8w) | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #117 (CVE-2026-54515) | `com.fasterxml.jackson.core:jackson-databind` | 2.21.4 | 2.21.5 |
| #105 (CVE-2026-45205) | `org.apache.commons:commons-configuration2` | 2.13.0 | 2.15.1 |

The Jackson fixes are property overrides on Spring Boot's managed BOMs; `commons-configuration2` is pinned via `dependencyManagement` rather than added as a direct dependency, since nothing here uses it directly.

Note for future maintenance: the Jackson properties must stay in `<properties>` and must not be moved to `-D` flags. As a command-line user property, `jackson-bom.version` leaks into third-party poms — log4j's parent uses the same property name for the Jackson 2 group BOM, which makes dependency resolution fail on a nonexistent `com.fasterxml.jackson:jackson-bom:3.1.5`.

## Exposure

None of the five are reachable in this connector; this is hygiene rather than an incident:

- No `@RestController` / `@RequestBody` exists here, so the connector never deserializes attacker-supplied JSON over HTTP. Jackson 3 is present only via `spring-boot-starter-web`.
- No `@JsonView`, `@JsonUnwrapped`, `@JsonTypeInfo`, or `ACCEPT_CASE_INSENSITIVE_PROPERTIES` in `src/`, so the preconditions for all three Jackson advisories are absent.
- `databricks-sdk-java` references only `INIConfiguration` / `SubnodeConfiguration` from commons-configuration2 (for `~/.databrickscfg`), while CVE-2026-45205 affects the YAML path. Auth is configured explicitly via host/clientId/secret in `Application.java`, so no profile file is read.

## Testing

`./mvnw test` passes. `./mvnw dependency:tree` confirms the three artifacts resolve to the patched versions.

## Notes / out of scope

- The pins should be removed once the managed versions catch up — the Jackson properties when a Spring Boot release ships the patched BOMs, `commons-configuration2` when `databricks-sdk-java` pins >= 2.15.0. A comment in `pom.xml` records this.
- `databricks-sdk-java` 0.132.0 → 0.136.0 is left for a separate PR; it carries no security fix relevant here.
- The other connectors share the SDK and Boot parent and likely have the same Jackson alerts open.
