### PR TITLE
Bump databricks-sdk-java from 0.132.0 to 0.136.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
 		<dependency>
 			<groupId>com.databricks</groupId>
 			<artifactId>databricks-sdk-java</artifactId>
-			<version>0.132.0</version>
+			<version>0.136.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
## Summary

Bumps `databricks-sdk-java` from 0.132.0 to 0.136.0 (latest). Maintenance only — no security content; the CVE work landed separately in #61.

### Breaking changes in the range

The four releases in the delta contain three breaking changes, none of them in the surface this connector uses:

| Release | Breaking change | Relevant |
|---|---|---|
| 0.134.0 | Remove `lifetime` field from `service.ml.TimeWindow` | No — ML service unused |
| 0.135.0 | `bundleDeployments().createDeployment()` new required argument order | No — unused |
| 0.135.0 | Remove `deploymentId` field from `bundledeployments.CreateDeploymentRequest` | No — unused |

This connector uses 25 SDK types, all under `service.catalog` and `service.iam`, plus `WorkspaceClient`, `AccountClient`, `DatabricksConfig`, and `error.platform.NotFound`. The only `service.catalog` change across the range is additive — new `SpecialDestination` enum values — and everything else in the release notes is new fields and methods.

### Dependency impact

Diffing the resolved dependency lists between 0.132.0 and 0.136.0 shows exactly one difference: the SDK jar itself. No transitive changes, so no new advisory surface. The pins added in #61 still resolve as intended on this branch — `jackson-databind` 2.21.5 / 3.1.5 and `commons-configuration2` 2.15.1.

Note that 0.136.0 still declares `commons-configuration2` 2.13.0, so the pin from #61 remains necessary and cannot be dropped as part of this bump.

## Testing

`./mvnw test` passes (12 tests). `./mvnw dependency:tree` confirms the pinned versions are unaffected by the bump.
