### PR TITLE
Bound memory usage of the asset synchronization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN useradd app
 USER app
 WORKDIR /app
 ENV OTEL_JAVAAGENT_ENABLED=false
+# Without this, the JVM caps the heap at 25% of the container memory. Overriding JAVA_TOOL_OPTIONS at
+# runtime replaces this value entirely, so any override must repeat the flags that should be kept.
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError"
 ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
 COPY --from=build /app/extracted/dependencies/ ./
 COPY --from=build /app/extracted/spring-boot-loader/ ./

--- a/README.md
+++ b/README.md
@@ -43,6 +43,45 @@ docker run \
 | `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CONNECTORID`                                   | `databricks-assets`                | Identifier for the Databricks assets connector.                                                                                          |
 | `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_ENABLED`                                       | `true`                             | Indicates whether Databricks asset tracking is enabled.                                                                              |
 | `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_POLLINTERVAL`                                  | `PT10M`                            | Polling interval for Databricks asset updates, in ISO 8601 duration format.                                                          |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CATALOGS_INCLUDE`                              |                                    | Comma-separated glob patterns of catalog names to synchronize, e.g. `prod,analytics_*`. Empty means all catalogs.                    |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CATALOGS_EXCLUDE`                              |                                    | Comma-separated glob patterns of catalog names to skip, e.g. `dev_*,staging`. Applied after the include patterns.                    |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_SCHEMAS_INCLUDE`                               |                                    | Comma-separated glob patterns of schema names to synchronize. Empty means all schemas.                                               |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_SCHEMAS_EXCLUDE`                               |                                    | Comma-separated glob patterns of schema names to skip, e.g. `tmp_*`. Applied after the include patterns.                             |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_TABLES_INCLUDE`                                |                                    | Comma-separated glob patterns of table names to synchronize. Empty means all tables.                                                 |
+| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_TABLES_EXCLUDE`                                |                                    | Comma-separated glob patterns of table names to skip, e.g. `*_backup`. Applied after the include patterns.                           |
+
+Patterns are matched case-insensitively against the plain catalog, schema, or table name, not against the fully qualified name.
+Only managed Unity Catalog catalogs are synchronized, and the `information_schema` is always skipped.
+
+### Scoping the Synchronization
+
+Large workspaces synchronize faster, and use less memory, when development or staging catalogs are excluded:
+
+```
+-e ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CATALOGS_EXCLUDE='dev_*,staging'
+```
+
+Catalogs are filtered before their schemas and tables are listed, so excluded catalogs cost no API calls at all.
+
+## Resources
+
+The connector needs **at least 1 GB of container memory**. The image sets a heap limit accordingly:
+
+```
+JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError
+```
+
+Without `MaxRAMPercentage`, the JVM caps the heap at 25% of the container memory, which is not enough to synchronize large
+Unity catalogs. `ExitOnOutOfMemoryError` terminates the container instead of leaving it running with a dead synchronization
+thread, so that your orchestrator can restart it.
+
+Setting `JAVA_TOOL_OPTIONS` at runtime **replaces** these flags rather than adding to them. Repeat the flags you want to keep:
+
+```
+-e JAVA_TOOL_OPTIONS='-XX:MaxRAMPercentage=60 -XX:+ExitOnOutOfMemoryError -javaagent:/agent.jar'
+```
+
+Expect the container to use around 60% of its memory limit under load. Adjust memory alarms accordingly.
 
 
 ## Access Management Flow

--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ Setting `JAVA_TOOL_OPTIONS` at runtime **replaces** these flags rather than addi
 
 Expect the container to use around 60% of its memory limit under load. Adjust memory alarms accordingly.
 
+### Synchronization Health
+
+The health endpoint reports whether the asset synchronization is still up to date:
+
+```
+curl http://localhost:8080/actuator/health
+```
+
+The `assetsSynchronizationHealth` component reports `DEGRADED` when the last run failed, or when no run has succeeded for three
+poll intervals, and names the failure in `lastFailure`. It is deliberately not reported as `DOWN`, and the endpoint still responds
+with 200, because the usual cause is an unavailable data platform, which restarting the container does not fix. Point liveness
+probes at `/actuator/health/liveness`, which is unaffected by the synchronization state.
+
 
 ## Access Management Flow
 

--- a/src/main/java/entropydata/databricks/Application.java
+++ b/src/main/java/entropydata/databricks/Application.java
@@ -68,17 +68,25 @@ public class Application {
     return entropyDataEventListener;
   }
 
+  @Bean
+  @ConditionalOnProperty(value = "entropydata.client.databricks.assets.enabled", havingValue = "true")
+  public AssetsSynchronizationHealth assetsSynchronizationHealth(DatabricksProperties databricksProperties) {
+    return new AssetsSynchronizationHealth(databricksProperties.assets().pollinterval());
+  }
+
   @Bean(destroyMethod = "stop")
   @ConditionalOnProperty(value = "entropydata.client.databricks.assets.enabled", havingValue = "true")
   public EntropyDataAssetsSynchronizer entropyDataAssetsSynchronizer(
       DatabricksProperties databricksProperties,
       EntropyDataClient client,
       WorkspaceClient workspaceClient,
+      AssetsSynchronizationHealth assetsSynchronizationHealth,
       TaskExecutor taskExecutor) {
     var connectorid = databricksProperties.assets().connectorid();
     var stateRepository = new EntropyDataStateRepositoryRemote(connectorid, client);
     var assetsSupplier = new DatabricksAssetsSupplier(workspaceClient, stateRepository, databricksProperties);
-    var entropyDataAssetsSynchronizer = new EntropyDataAssetsSynchronizer(connectorid, client, assetsSupplier);
+    var entropyDataAssetsSynchronizer = new EntropyDataAssetsSynchronizer(connectorid, client,
+        assetsSynchronizationHealth.wrap(assetsSupplier));
     if (databricksProperties.assets().pollinterval() != null) {
       entropyDataAssetsSynchronizer.setDelay(databricksProperties.assets().pollinterval());
     }

--- a/src/main/java/entropydata/databricks/AssetsSynchronizationHealth.java
+++ b/src/main/java/entropydata/databricks/AssetsSynchronizationHealth.java
@@ -1,0 +1,77 @@
+package entropydata.databricks;
+
+import entropydata.sdk.EntropyDataAssetsProvider;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+
+/**
+ * Reports whether the asset synchronization is still up to date. It wraps the assets provider, so that a failed run, or a
+ * synchronization that no longer runs at all, becomes visible instead of the connector reporting itself as healthy.
+ */
+public class AssetsSynchronizationHealth implements EntropyDataAssetsProvider, HealthIndicator {
+
+  /**
+   * Reported instead of DOWN, because the usual cause is an unavailable data platform. Restarting the container, which is what an
+   * orchestrator does when a health check reports DOWN, does not resolve that.
+   */
+  private static final Status DEGRADED = new Status("DEGRADED");
+
+  private static final Duration DEFAULT_POLL_INTERVAL = Duration.ofHours(1);
+  private static final int MISSED_RUNS_UNTIL_DEGRADED = 3;
+
+  private final Duration degradedAfter;
+
+  private volatile EntropyDataAssetsProvider delegate;
+  private volatile Instant lastSuccessAt;
+  private volatile String lastFailure;
+
+  public AssetsSynchronizationHealth(Duration pollInterval) {
+    this.degradedAfter = Objects.requireNonNullElse(pollInterval, DEFAULT_POLL_INTERVAL).multipliedBy(MISSED_RUNS_UNTIL_DEGRADED);
+  }
+
+  /**
+   * Returns a provider that reports the outcome of every run to this indicator.
+   */
+  public EntropyDataAssetsProvider wrap(EntropyDataAssetsProvider delegate) {
+    this.delegate = delegate;
+    return this;
+  }
+
+  @Override
+  public void fetchAssets(AssetCallback callback) {
+    try {
+      delegate.fetchAssets(callback);
+      this.lastSuccessAt = Instant.now();
+      this.lastFailure = null;
+    } catch (Exception e) {
+      this.lastFailure = e.toString();
+      throw e;
+    }
+  }
+
+  @Override
+  public Health health() {
+    var lastSuccess = this.lastSuccessAt;
+    var failure = this.lastFailure;
+
+    Health.Builder health;
+    if (lastSuccess == null) {
+      health = Health.status(failure == null ? Status.UNKNOWN : DEGRADED);
+    } else if (Duration.between(lastSuccess, Instant.now()).compareTo(degradedAfter) > 0) {
+      health = Health.status(DEGRADED);
+    } else {
+      health = Health.up();
+    }
+
+    health.withDetail("lastSuccessfulSynchronizationAt", lastSuccess != null ? lastSuccess.toString() : "never");
+    health.withDetail("degradedAfter", degradedAfter.toString());
+    if (failure != null) {
+      health.withDetail("lastFailure", failure);
+    }
+    return health.build();
+  }
+}

--- a/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
+++ b/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
@@ -4,6 +4,8 @@ import com.databricks.sdk.WorkspaceClient;
 import com.databricks.sdk.service.catalog.CatalogInfo;
 import com.databricks.sdk.service.catalog.CatalogType;
 import com.databricks.sdk.service.catalog.ListCatalogsRequest;
+import com.databricks.sdk.service.catalog.ListSchemasRequest;
+import com.databricks.sdk.service.catalog.ListTablesRequest;
 import com.databricks.sdk.service.catalog.SchemaInfo;
 import com.databricks.sdk.service.catalog.TableInfo;
 import entropydata.sdk.EntropyDataAssetsProvider;
@@ -23,15 +25,27 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
 
   private static final Logger log = LoggerFactory.getLogger(DatabricksAssetsSupplier.class);
 
+  /**
+   * Without a page size, the Unity Catalog list APIs return every entry in a single response, which has to be held in memory at once. Zero
+   * requests the server configured page size, so the SDK paginates instead.
+   */
+  private static final long SERVER_CONFIGURED_PAGE_SIZE = 0L;
+
   private final WorkspaceClient workspaceClient;
   private final EntropyDataStateRepository entropyDataStateRepository;
   private final DatabricksProperties databricksProperties;
+  private final NameFilter catalogFilter;
+  private final NameFilter schemaFilter;
+  private final NameFilter tableFilter;
 
   public DatabricksAssetsSupplier(WorkspaceClient workspaceClient, EntropyDataStateRepository entropyDataStateRepository,
       DatabricksProperties databricksProperties) {
     this.workspaceClient = workspaceClient;
     this.entropyDataStateRepository = entropyDataStateRepository;
     this.databricksProperties = databricksProperties;
+    this.catalogFilter = NameFilter.of(databricksProperties.assets().catalogs());
+    this.schemaFilter = NameFilter.of(databricksProperties.assets().schemas());
+    this.tableFilter = NameFilter.of(databricksProperties.assets().tables());
   }
 
   @Override
@@ -39,28 +53,43 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
     final var databricksLastUpdatedAt = getLastUpdatedAt();
     var databricksLastUpdatedAtThisRunMax = databricksLastUpdatedAt;
 
-    var catalogs = workspaceClient.catalogs().list(new ListCatalogsRequest());
+    var catalogs = workspaceClient.catalogs().list(new ListCatalogsRequest()
+        .setMaxResults(SERVER_CONFIGURED_PAGE_SIZE));
     for (var catalog : catalogs) {
       if (!includeCatalog(catalog)) {
+        log.debug("Skipping catalog {} of type {}", catalog.getFullName(), catalog.getCatalogType());
         continue;
       }
 
       log.info("Synchronizing catalog {}", catalog.getFullName());
       catalogToAsset(catalog, databricksLastUpdatedAt).ifPresent(assetCallback::onAssetUpdated);
 
-      var schemas = workspaceClient.schemas().list(catalog.getFullName());
+      var schemas = workspaceClient.schemas().list(new ListSchemasRequest()
+          .setCatalogName(catalog.getFullName())
+          .setMaxResults(SERVER_CONFIGURED_PAGE_SIZE));
       long schemasCount = 0;
       for (var schema : schemas) {
         if (!includeSchema(schema)) {
+          log.debug("Skipping schema {}", schema.getFullName());
           continue;
         }
 
         log.info("Synchronizing schema {}", schema.getFullName());
         schemaToAsset(schema, catalog, databricksLastUpdatedAt).ifPresent(assetCallback::onAssetUpdated);
 
-        var tables = workspaceClient.tables().list(schema.getCatalogName(), schema.getName());
+        var tables = workspaceClient.tables().list(new ListTablesRequest()
+            .setCatalogName(schema.getCatalogName())
+            .setSchemaName(schema.getName())
+            .setMaxResults(SERVER_CONFIGURED_PAGE_SIZE)
+            .setOmitProperties(true)
+            .setOmitUsername(true));
         long tablesCount = 0;
         for (var table : tables) {
+          if (!includeTable(table)) {
+            log.debug("Skipping table {}", table.getFullName());
+            continue;
+          }
+
           tableToAsset(table, schema, databricksLastUpdatedAt).ifPresent(assetCallback::onAssetUpdated);
 
           databricksLastUpdatedAtThisRunMax = Math.max(databricksLastUpdatedAtThisRunMax, table.getUpdatedAt());
@@ -216,22 +245,22 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
   }
 
   protected boolean includeCatalog(CatalogInfo catalog) {
-    if (catalog.getCatalogType() == CatalogType.MANAGED_CATALOG) {
-      return true;
+    if (catalog.getCatalogType() != CatalogType.MANAGED_CATALOG) {
+      return false;
     }
 
-    return false;
+    return catalogFilter.matches(catalog.getName());
   }
 
   protected boolean includeSchema(SchemaInfo schema) {
     if (Objects.equals(schema.getName(), "information_schema")) {
       return false;
     }
-    return true;
+    return schemaFilter.matches(schema.getName());
   }
 
   protected boolean includeTable(TableInfo table) {
-    return true;
+    return tableFilter.matches(table.getName());
   }
 
   private boolean alreadySynchronized(CatalogInfo catalogInfo, Long databricksLastUpdatedAt) {

--- a/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
+++ b/src/main/java/entropydata/databricks/DatabricksAssetsSupplier.java
@@ -14,6 +14,7 @@ import entropydata.sdk.client.model.Asset;
 import entropydata.sdk.client.model.AssetColumn;
 import entropydata.sdk.client.model.AssetInfo;
 import entropydata.sdk.client.model.AssetRelationshipsInner;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -30,6 +31,14 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
    * requests the server configured page size, so the SDK paginates instead.
    */
   private static final long SERVER_CONFIGURED_PAGE_SIZE = 0L;
+
+  /**
+   * A run reads catalogs, schemas, and tables over a longer period, and anything modified after it has been read must still be picked up
+   * by the next run. The watermark is therefore taken before the first entity is read, minus an overlap that absorbs clock differences
+   * between this process and Databricks. Entities within the overlap are read again and compared, which does not write anything unless
+   * they actually changed.
+   */
+  private static final Duration WATERMARK_OVERLAP = Duration.ofHours(1);
 
   private final WorkspaceClient workspaceClient;
   private final EntropyDataStateRepository entropyDataStateRepository;
@@ -51,7 +60,7 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
   @Override
   public void fetchAssets(AssetCallback assetCallback) {
     final var databricksLastUpdatedAt = getLastUpdatedAt();
-    var databricksLastUpdatedAtThisRunMax = databricksLastUpdatedAt;
+    final var watermark = System.currentTimeMillis() - WATERMARK_OVERLAP.toMillis();
 
     var catalogs = workspaceClient.catalogs().list(new ListCatalogsRequest()
         .setMaxResults(SERVER_CONFIGURED_PAGE_SIZE));
@@ -92,7 +101,6 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
 
           tableToAsset(table, schema, databricksLastUpdatedAt).ifPresent(assetCallback::onAssetUpdated);
 
-          databricksLastUpdatedAtThisRunMax = Math.max(databricksLastUpdatedAtThisRunMax, table.getUpdatedAt());
           tablesCount++;
         }
         log.info("Synchronized {} tables in schema {}", tablesCount, schema.getFullName());
@@ -101,7 +109,7 @@ public class DatabricksAssetsSupplier implements EntropyDataAssetsProvider {
       log.info("Synchronized {} schemas in catalog {}", schemasCount, catalog.getFullName());
     }
 
-    setLastUpdatedAt(databricksLastUpdatedAtThisRunMax);
+    setLastUpdatedAt(watermark);
   }
 
   private Long getLastUpdatedAt() {

--- a/src/main/java/entropydata/databricks/DatabricksProperties.java
+++ b/src/main/java/entropydata/databricks/DatabricksProperties.java
@@ -1,6 +1,7 @@
 package entropydata.databricks;
 
 import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "entropydata.client.databricks")
@@ -31,7 +32,17 @@ public record DatabricksProperties(
   public record AssetsProperties(
       Boolean enabled,
       String connectorid,
-      Duration pollinterval
+      Duration pollinterval,
+      FilterProperties catalogs,
+      FilterProperties schemas,
+      FilterProperties tables
+  ) {
+
+  }
+
+  public record FilterProperties(
+      List<String> include,
+      List<String> exclude
   ) {
 
   }

--- a/src/main/java/entropydata/databricks/NameFilter.java
+++ b/src/main/java/entropydata/databricks/NameFilter.java
@@ -1,0 +1,45 @@
+package entropydata.databricks;
+
+import entropydata.databricks.DatabricksProperties.FilterProperties;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Matches catalog, schema, and table names against configured glob patterns. An empty include list matches everything.
+ */
+record NameFilter(List<Pattern> include, List<Pattern> exclude) {
+
+  static NameFilter of(FilterProperties properties) {
+    if (properties == null) {
+      return new NameFilter(List.of(), List.of());
+    }
+    return new NameFilter(compile(properties.include()), compile(properties.exclude()));
+  }
+
+  boolean matches(String name) {
+    if (!include.isEmpty() && include.stream().noneMatch(pattern -> pattern.matcher(name).matches())) {
+      return false;
+    }
+    return exclude.stream().noneMatch(pattern -> pattern.matcher(name).matches());
+  }
+
+  private static List<Pattern> compile(List<String> globs) {
+    if (globs == null) {
+      return List.of();
+    }
+    return globs.stream()
+        .filter(glob -> !glob.isBlank())
+        .map(NameFilter::toPattern)
+        .toList();
+  }
+
+  private static Pattern toPattern(String glob) {
+    var regex = Arrays.stream(glob.trim().split("\\*", -1))
+        .map(Pattern::quote)
+        .collect(Collectors.joining(".*"));
+    // Unity Catalog identifiers are case-insensitive
+    return Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,9 @@ entropydata.client.databricks.assets.schemas.include=
 entropydata.client.databricks.assets.schemas.exclude=
 entropydata.client.databricks.assets.tables.include=
 entropydata.client.databricks.assets.tables.exclude=
+
+# The synchronization health is reported as a component of the health endpoint, which is only rendered with details enabled
+management.endpoint.health.show-details=always
+# DEGRADED ranks above UP, so that it shows in the aggregated status. It is not mapped to an error response, because
+# restarting the container does not fix an unavailable data platform.
+management.endpoint.health.status.order=DOWN,OUT_OF_SERVICE,DEGRADED,UP,UNKNOWN

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,4 +16,11 @@ entropydata.client.databricks.accessmanagement.enabled=true
 entropydata.client.databricks.assets.connectorid=databricks-assets
 entropydata.client.databricks.assets.enabled=true
 entropydata.client.databricks.assets.pollinterval=PT10M
-entropydata.client.databricks.assets.tables.include=*
+
+# Comma-separated glob patterns matched against the catalog, schema, and table name. An empty include list matches everything.
+entropydata.client.databricks.assets.catalogs.include=
+entropydata.client.databricks.assets.catalogs.exclude=
+entropydata.client.databricks.assets.schemas.include=
+entropydata.client.databricks.assets.schemas.exclude=
+entropydata.client.databricks.assets.tables.include=
+entropydata.client.databricks.assets.tables.exclude=

--- a/src/test/java/entropydata/databricks/AssetsSynchronizationHealthTest.java
+++ b/src/test/java/entropydata/databricks/AssetsSynchronizationHealthTest.java
@@ -1,0 +1,72 @@
+package entropydata.databricks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import entropydata.sdk.EntropyDataAssetsProvider;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.health.contributor.Status;
+
+class AssetsSynchronizationHealthTest {
+
+  private static final EntropyDataAssetsProvider SUCCEEDS = callback -> {
+  };
+
+  private static final EntropyDataAssetsProvider FAILS = callback -> {
+    throw new IllegalStateException("Data platform is unavailable");
+  };
+
+  private static AssetsSynchronizationHealth wrapping(EntropyDataAssetsProvider provider, Duration pollInterval) {
+    var indicator = new AssetsSynchronizationHealth(pollInterval);
+    indicator.wrap(provider);
+    return indicator;
+  }
+
+  @Test
+  void isUnknownBeforeTheFirstRunHasFinished() {
+    var health = wrapping(SUCCEEDS, Duration.ofMinutes(10)).health();
+
+    assertThat(health.getStatus()).isEqualTo(Status.UNKNOWN);
+    assertThat(health.getDetails()).containsEntry("lastSuccessfulSynchronizationAt", "never");
+  }
+
+  @Test
+  void isUpAfterASuccessfulRun() {
+    var indicator = wrapping(SUCCEEDS, Duration.ofMinutes(10));
+
+    indicator.fetchAssets(null);
+
+    assertThat(indicator.health().getStatus()).isEqualTo(Status.UP);
+  }
+
+  @Test
+  void isDegradedAfterAFailedRunAndRethrowsTheFailure() {
+    var indicator = wrapping(FAILS, Duration.ofMinutes(10));
+
+    assertThatThrownBy(() -> indicator.fetchAssets(null)).isInstanceOf(IllegalStateException.class);
+
+    var health = indicator.health();
+    assertThat(health.getStatus()).isEqualTo(new Status("DEGRADED"));
+    assertThat(health.getDetails().get("lastFailure").toString()).contains("Data platform is unavailable");
+  }
+
+  @Test
+  void isDegradedWhenTheLastSuccessfulRunIsTooLongAgo() throws Exception {
+    var indicator = wrapping(SUCCEEDS, Duration.ofMillis(1));
+
+    indicator.fetchAssets(null);
+    Thread.sleep(50);
+
+    assertThat(indicator.health().getStatus()).isEqualTo(new Status("DEGRADED"));
+  }
+
+  @Test
+  void doesNotReportDownSoThatAnUnavailableDataPlatformCannotTriggerRestarts() {
+    var indicator = wrapping(FAILS, Duration.ofMinutes(10));
+
+    assertThatThrownBy(() -> indicator.fetchAssets(null)).isInstanceOf(IllegalStateException.class);
+
+    assertThat(indicator.health().getStatus()).isNotEqualTo(Status.DOWN);
+  }
+}

--- a/src/test/java/entropydata/databricks/DatabricksAssetsSupplierTest.java
+++ b/src/test/java/entropydata/databricks/DatabricksAssetsSupplierTest.java
@@ -1,0 +1,153 @@
+package entropydata.databricks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.databricks.sdk.WorkspaceClient;
+import com.databricks.sdk.service.catalog.CatalogInfo;
+import com.databricks.sdk.service.catalog.CatalogType;
+import com.databricks.sdk.service.catalog.ListCatalogsRequest;
+import com.databricks.sdk.service.catalog.ListSchemasRequest;
+import com.databricks.sdk.service.catalog.ListTablesRequest;
+import com.databricks.sdk.service.catalog.SchemaInfo;
+import com.databricks.sdk.service.catalog.TableInfo;
+import entropydata.databricks.DatabricksProperties.AccessmanagementProperties;
+import entropydata.databricks.DatabricksProperties.AccountProperties;
+import entropydata.databricks.DatabricksProperties.AssetsProperties;
+import entropydata.databricks.DatabricksProperties.FilterProperties;
+import entropydata.databricks.DatabricksProperties.WorkspaceProperties;
+import entropydata.sdk.EntropyDataAssetsProvider.AssetCallback;
+import entropydata.sdk.EntropyDataStateRepository;
+import entropydata.sdk.client.model.Asset;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class DatabricksAssetsSupplierTest {
+
+  private WorkspaceClient workspaceClient;
+  private EntropyDataStateRepository stateRepository;
+
+  @BeforeEach
+  void setUp() {
+    workspaceClient = mock(WorkspaceClient.class, RETURNS_DEEP_STUBS);
+    stateRepository = mock(EntropyDataStateRepository.class);
+    when(stateRepository.getState()).thenReturn(Map.of());
+
+    when(workspaceClient.catalogs().list(any(ListCatalogsRequest.class))).thenReturn(List.of(
+        new CatalogInfo().setName("prod").setFullName("prod").setCatalogType(CatalogType.MANAGED_CATALOG).setUpdatedAt(1L)));
+    when(workspaceClient.schemas().list(any(ListSchemasRequest.class))).thenReturn(List.of(
+        schema("sales"), schema("tmp_import")));
+    when(workspaceClient.tables().list(any(ListTablesRequest.class))).thenReturn(List.of(
+        table("orders"), table("orders_backup")));
+  }
+
+  @Test
+  void requestsPagedResultsToBoundMemoryUsage() {
+    supplier(assets(null, null, null)).fetchAssets(collectAssets(new ArrayList<>()));
+
+    var catalogsRequest = ArgumentCaptor.forClass(ListCatalogsRequest.class);
+    verify(workspaceClient.catalogs()).list(catalogsRequest.capture());
+    assertThat(catalogsRequest.getValue().getMaxResults()).isZero();
+
+    var schemasRequest = ArgumentCaptor.forClass(ListSchemasRequest.class);
+    verify(workspaceClient.schemas()).list(schemasRequest.capture());
+    assertThat(schemasRequest.getValue().getMaxResults()).isZero();
+    assertThat(schemasRequest.getValue().getCatalogName()).isEqualTo("prod");
+
+    var tablesRequest = ArgumentCaptor.forClass(ListTablesRequest.class);
+    verify(workspaceClient.tables(), org.mockito.Mockito.atLeastOnce()).list(tablesRequest.capture());
+    assertThat(tablesRequest.getValue().getMaxResults()).isZero();
+    assertThat(tablesRequest.getValue().getOmitProperties()).isTrue();
+    assertThat(tablesRequest.getValue().getOmitUsername()).isTrue();
+  }
+
+  @Test
+  void synchronizesEverythingWhenNoFiltersAreConfigured() {
+    var assets = new ArrayList<Asset>();
+
+    supplier(assets(null, null, null)).fetchAssets(collectAssets(assets));
+
+    assertThat(qualifiedNames(assets)).contains("prod", "prod.sales", "prod.tmp_import", "prod.sales.orders");
+  }
+
+  @Test
+  void skipsExcludedSchemasAndTables() {
+    var assets = new ArrayList<Asset>();
+    var properties = assets(null,
+        new FilterProperties(List.of(), List.of("tmp_*")),
+        new FilterProperties(List.of(), List.of("*_backup")));
+
+    supplier(properties).fetchAssets(collectAssets(assets));
+
+    assertThat(qualifiedNames(assets)).contains("prod.sales", "prod.sales.orders");
+    assertThat(qualifiedNames(assets)).doesNotContain("prod.tmp_import", "prod.sales.orders_backup");
+  }
+
+  @Test
+  void skipsCatalogsThatAreNotIncluded() {
+    var assets = new ArrayList<Asset>();
+    var properties = assets(new FilterProperties(List.of("analytics_*"), List.of()), null, null);
+
+    supplier(properties).fetchAssets(collectAssets(assets));
+
+    assertThat(assets).isEmpty();
+  }
+
+  private DatabricksAssetsSupplier supplier(AssetsProperties assetsProperties) {
+    var properties = new DatabricksProperties(
+        new WorkspaceProperties("https://example.cloud.databricks.com", "client-id", "client-secret"),
+        new AccountProperties("https://accounts.cloud.databricks.com", "account-id", "client-id", "client-secret"),
+        assetsProperties,
+        new AccessmanagementProperties(false, "databricks-access-management"));
+    return new DatabricksAssetsSupplier(workspaceClient, stateRepository, properties);
+  }
+
+  private static AssetsProperties assets(FilterProperties catalogs, FilterProperties schemas, FilterProperties tables) {
+    return new AssetsProperties(true, "databricks-assets", Duration.parse("PT10M"), catalogs, schemas, tables);
+  }
+
+  private static SchemaInfo schema(String name) {
+    return new SchemaInfo()
+        .setName(name)
+        .setFullName("prod." + name)
+        .setCatalogName("prod")
+        .setSchemaId("schema-" + name)
+        .setUpdatedAt(1L);
+  }
+
+  private static TableInfo table(String name) {
+    return new TableInfo()
+        .setName(name)
+        .setFullName("prod.sales." + name)
+        .setCatalogName("prod")
+        .setSchemaName("sales")
+        .setTableId("table-" + name)
+        .setUpdatedAt(1L);
+  }
+
+  private static AssetCallback collectAssets(List<Asset> assets) {
+    return new AssetCallback() {
+      @Override
+      public void onAssetUpdated(Asset asset) {
+        assets.add(asset);
+      }
+
+      @Override
+      public void onAssetDeleted(String id) {
+      }
+    };
+  }
+
+  private static List<String> qualifiedNames(List<Asset> assets) {
+    return assets.stream().map(asset -> asset.getInfo().getQualifiedName()).toList();
+  }
+}

--- a/src/test/java/entropydata/databricks/DatabricksAssetsSupplierTest.java
+++ b/src/test/java/entropydata/databricks/DatabricksAssetsSupplierTest.java
@@ -93,6 +93,21 @@ class DatabricksAssetsSupplierTest {
   }
 
   @Test
+  void takesTheWatermarkFromTheStartOfTheRunInsteadOfTheEntitiesItSaw() {
+    var before = System.currentTimeMillis();
+
+    supplier(assets(null, null, null)).fetchAssets(collectAssets(new ArrayList<>()));
+
+    var state = ArgumentCaptor.forClass(Map.class);
+    verify(stateRepository).saveState(state.capture());
+    var watermark = (Long) state.getValue().get("lastUpdatedAt");
+
+    // Anything modified while the run was in progress must be read again by the next run
+    assertThat(watermark).isLessThanOrEqualTo(before);
+    assertThat(watermark).isGreaterThan(before - Duration.ofHours(2).toMillis());
+  }
+
+  @Test
   void skipsCatalogsThatAreNotIncluded() {
     var assets = new ArrayList<Asset>();
     var properties = assets(new FilterProperties(List.of("analytics_*"), List.of()), null, null);

--- a/src/test/java/entropydata/databricks/NameFilterTest.java
+++ b/src/test/java/entropydata/databricks/NameFilterTest.java
@@ -1,0 +1,73 @@
+package entropydata.databricks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import entropydata.databricks.DatabricksProperties.FilterProperties;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NameFilterTest {
+
+  @Test
+  void matchesEverythingWhenNotConfigured() {
+    var filter = NameFilter.of(null);
+
+    assertThat(filter.matches("prod")).isTrue();
+    assertThat(filter.matches("dev_sandbox")).isTrue();
+  }
+
+  @Test
+  void matchesEverythingWhenListsAreEmpty() {
+    var filter = NameFilter.of(new FilterProperties(List.of(), List.of()));
+
+    assertThat(filter.matches("prod")).isTrue();
+  }
+
+  @Test
+  void excludesByGlob() {
+    var filter = NameFilter.of(new FilterProperties(List.of(), List.of("dev_*", "staging")));
+
+    assertThat(filter.matches("prod")).isTrue();
+    assertThat(filter.matches("dev_sandbox")).isFalse();
+    assertThat(filter.matches("staging")).isFalse();
+  }
+
+  @Test
+  void includesOnlyMatchingNames() {
+    var filter = NameFilter.of(new FilterProperties(List.of("prod", "analytics_*"), List.of()));
+
+    assertThat(filter.matches("prod")).isTrue();
+    assertThat(filter.matches("analytics_eu")).isTrue();
+    assertThat(filter.matches("prod_backup")).isFalse();
+  }
+
+  @Test
+  void excludeWinsOverInclude() {
+    var filter = NameFilter.of(new FilterProperties(List.of("prod_*"), List.of("prod_tmp")));
+
+    assertThat(filter.matches("prod_sales")).isTrue();
+    assertThat(filter.matches("prod_tmp")).isFalse();
+  }
+
+  @Test
+  void ignoresBlankPatternsFromEmptyConfiguration() {
+    var filter = NameFilter.of(new FilterProperties(List.of(""), List.of("")));
+
+    assertThat(filter.matches("prod")).isTrue();
+  }
+
+  @Test
+  void matchesCaseInsensitively() {
+    var filter = NameFilter.of(new FilterProperties(List.of(), List.of("DEV_*")));
+
+    assertThat(filter.matches("dev_sandbox")).isFalse();
+  }
+
+  @Test
+  void treatsGlobLiteralsAsText() {
+    var filter = NameFilter.of(new FilterProperties(List.of("sales.eu"), List.of()));
+
+    assertThat(filter.matches("sales.eu")).isTrue();
+    assertThat(filter.matches("salesXeu")).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the out-of-memory condition in the asset synchronization (DMM-523), and the two correctness problems found alongside it.

**Page the Unity Catalog list APIs.** `catalogs().list()`, `schemas().list()`, and `tables().list()` were called without a page size. The API then returns every entry in a single response ("If not set, all the tables are returned (not recommended)"), so an entire schema — every table, with all columns and properties — had to be deserialized and held in memory at once. Peak memory scaled with the largest schema in the workspace. Requesting the server configured page size (`maxResults=0`) lets the SDK's `Paginator` do its job, and `omitProperties`/`omitUsername` drop two fields that are never mapped to assets.

**Set a heap limit.** The image passed no heap flag, so the JVM defaulted to 25% of the container memory — a 512 MB container ran with a 128 MB heap. The image now sets `-XX:MaxRAMPercentage=60`, sized against a measured non-heap footprint of roughly 190 MB. `-XX:+ExitOnOutOfMemoryError` is set as well: an `OutOfMemoryError` previously killed only the thread that happened to be allocating, leaving the container running and reporting healthy while it no longer synchronized anything.

**Add scoping patterns.** Six new properties include or exclude catalogs, schemas, and tables by glob pattern, so development and staging catalogs can be left out entirely. Catalogs are filtered before their schemas and tables are listed, so an excluded catalog costs no API calls. This matters beyond memory: a run that never completes never persists its watermark, so it can never become incremental.

This replaces `entropydata.client.databricks.assets.tables.include`, which shipped in `application.properties` but had no corresponding field in `AssetsProperties` — the Spring binder ignored it, so it silently had no effect. Anyone who had set it expecting it to filter will now see it applied.

**Take the watermark from the start of the run.** The watermark was the highest `updatedAt` of all tables seen. A run reads entities over a long period, so anything modified after it was read, but before the run finished, ended up with an `updatedAt` below the new watermark and was treated as already synchronized on every following run — its change was never picked up. The watermark is now taken before the first entity is read, minus an overlap that absorbs clock differences with Databricks. Entities inside the overlap are read again and compared, which writes nothing unless they actually changed.

**Report synchronization health.** A failed run, or a synchronization that no longer runs, was invisible — the health endpoint answered 200 regardless. The `assetsSynchronizationHealth` component now reports `DEGRADED` when the last run failed or no run has succeeded for three poll intervals, and names the failure. `DEGRADED` is deliberately not mapped to an error response: the usual cause is an unavailable data platform, and restarting the container does not fix that. Liveness probes are unaffected.

Defaults preserve the current behaviour: empty include and exclude lists match everything.

## Configuration

| Environment Variable | Default | Description |
|---|---|---|
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CATALOGS_INCLUDE` | | Glob patterns of catalog names to synchronize |
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_CATALOGS_EXCLUDE` | | Glob patterns of catalog names to skip |
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_SCHEMAS_INCLUDE` | | Glob patterns of schema names to synchronize |
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_SCHEMAS_EXCLUDE` | | Glob patterns of schema names to skip |
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_TABLES_INCLUDE` | | Glob patterns of table names to synchronize |
| `ENTROPYDATA_CLIENT_DATABRICKS_ASSETS_TABLES_EXCLUDE` | | Glob patterns of table names to skip |

## Testing

30 tests pass. `NameFilterTest` covers the pattern semantics, `DatabricksAssetsSupplierTest` asserts that the list requests carry the page size and omit flags, that the filters skip the right entities, and that the watermark comes from the start of the run, and `AssetsSynchronizationHealthTest` covers the health states.

Verified end to end by running the built image against a stubbed Entropy Data API with an unreachable Databricks host: the heap flag is picked up, and `/actuator/health` answers 200 with the aggregate and the component reporting `DEGRADED`, `lastFailure` naming the connection error, and `livenessState` still `UP`.

## Notes

- Deployments need **at least 1 GB of container memory**; at 512 MB the heap flag has no room to help. Documented in the README.
- Memory usage rises from roughly 25% to 60% of the limit under load. Alarms thresholded below that will need retuning.
- Setting `JAVA_TOOL_OPTIONS` at runtime replaces the image value rather than merging with it. Documented in the README.
- `management.endpoint.health.show-details` is now `always`, so the health endpoint exposes component details.

## Out of scope

- Assets are never deleted — `onAssetDeleted` is never called, so tables removed in Databricks, or now excluded by a filter, remain in Entropy Data.
- Reporting connector health back to Entropy Data. The `Connector` schema has no health field, so a failing connector stays invisible in the UI even though it is now visible on its own health endpoint.