### PR TITLE
Publish a versioned image for every release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: entropydata/entropy-data-connector-databricks:latest
+          tags: entropydata/entropy-data-connector-databricks:sha-${{ github.sha }}
           sbom: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      TAG_NAME:
+        description: Tag name to be used for the docker build, e.g., 0.9.0
+        required: true
+
+env:
+  TAG_NAME: ${{ github.event.inputs.TAG_NAME || github.event.release.tag_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Keyless cosign exchanges this OIDC token for a Fulcio certificate
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      # Stamps the released version into the jar manifest, so the connector can report the version it runs with
+      - name: Set version
+        run: mvn versions:set -DnewVersion=${{ env.TAG_NAME }} -DgenerateBackupPoms=false
+
+      # The image build skips the tests, so they run here as a release gate
+      - name: Run tests
+        run: mvn -B test --file pom.xml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            entropydata/entropy-data-connector-databricks:latest,
+            entropydata/entropy-data-connector-databricks:${{ env.TAG_NAME }}
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # cosign-installer publishes no floating major tag, so this must name an exact version.
+      - uses: sigstore/cosign-installer@v4.1.2
+
+      # Sign the index digest rather than a tag: the index commits to the platform manifests and the
+      # SBOM/provenance attestations, so one signature covers all of them, and the binding cannot be
+      # moved by retagging.
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "entropydata/entropy-data-connector-databricks@${DIGEST}"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ docker run \
   entropydata/entropy-data-connector-databricks:latest
 ```
 
+## Versions
+
+Every release is published as an immutable image tag. Pin a version rather than following `latest`:
+
+```
+entropydata/entropy-data-connector-databricks:0.9.0
+```
+
+| Tag | Meaning |
+|---|---|
+| `X.Y.Z` | A released version. Immutable, and the recommended way to run the connector. |
+| `latest` | The most recent release. Moves with every release. |
+| `sha-<commit>` | A single commit on `main`, published so that a change can be tried out before it is released. |
+
+Release images are signed with [cosign](https://docs.sigstore.dev/), and carry an SBOM and build provenance:
+
+```
+cosign verify entropydata/entropy-data-connector-databricks:0.9.0 \
+  --certificate-identity-regexp 'https://github.com/entropy-data/entropy-data-connector-databricks/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
 ## Configuration
 
 | Environment Variable                                                                 | Default Value                      | Description                                                                                                                          |


### PR DESCRIPTION
## Summary

Only `:latest` was published, and every push to `main` overwrote it. A customer could not pin a version, and could not tell which build a running container came from — there are no git tags and no GitHub releases in this repository today.

A `release.yml` now publishes on a GitHub release, following the release workflow of the entropy-data application:

- `mvn versions:set` writes the release tag into the pom before the image is built, so the version travels into the jar manifest
- the image is pushed as both `:latest` and `:<version>`
- the image carries an SBOM and build provenance, and is signed with keyless cosign
- `workflow_dispatch` with a `TAG_NAME` input allows re-publishing a version without cutting a new release
- the tests run as a release gate, because the image build skips them

Pushes to `main` no longer overwrite `:latest`. They publish an immutable `sha-<commit>` tag instead, so a change can still be tried out before it is released, while `:latest` comes to mean "the most recent release" as it does for the application.

The version scheme is semver per connector, since the connectors release independently of each other.

## Notes

- `latest` keeps pointing at the current build until the first release is cut. Cutting `0.9.0` right after this merges avoids a stale `latest`.
- Reporting the running version back to Entropy Data needs entropy-data/entropy-data-sdk#90 released first; it is a follow-up, not part of this change.
- Verified with `actionlint`; both workflows lint clean.