### PR TITLE
Name the cosign version needed to verify a release image

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ entropydata/entropy-data-connector-databricks:0.3.0
 | `latest` | The most recent release. Moves with every release. |
 | `sha-<commit>` | A single commit on `main`, published so that a change can be tried out before it is released. |
 
-Release images are signed with [cosign](https://docs.sigstore.dev/), and carry an SBOM and build provenance:
+Release images are signed with [cosign](https://docs.sigstore.dev/), and carry an SBOM and build provenance.
+Verifying needs **cosign 3 or later**, because the signatures use the OCI referrers format that cosign 2 cannot read
+(it reports `no signatures found`):
 
 ```
 cosign verify entropydata/entropy-data-connector-databricks:0.3.0 \


### PR DESCRIPTION
Release images are signed with cosign 3, which stores the signature in the OCI referrers format. Verifying with cosign 2 reports `no signatures found` even though the image is correctly signed, so the README now names the version the documented command needs.

Found while verifying the 0.3.0 images: the signature is valid, but only cosign 3 can see it.